### PR TITLE
gh-8 Include OpenID Connect plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
             args:
                 MDM_APPLICATION_COMMIT: "${MDM_APPLICATION_COMMIT}"
                 MDM_UI_COMMIT: "${MDM_UI_COMMIT}"
-                ADDITIONAL_PLUGINS: "uk.ac.ox.softeng.maurodatamapper.plugins:mdm-plugin-nhs-data-dictionary:2.0.0-SNAPSHOT"
+                ADDITIONAL_PLUGINS: "uk.ac.ox.softeng.maurodatamapper.plugins:mdm-plugin-nhs-data-dictionary:2.0.0-SNAPSHOT;uk.ac.ox.softeng.maurodatamapper.plugins:mdm-plugin-authentication-openid-connect:2.2.0"
                 MDM_UI_THEME_NAME: "nhs-digital"
                 CACHE_BURST: "${CACHE_BURST}"
                 NHSD_DD_ORCHESTRATION_API_ENDPOINT: "http://localhost:${MDM_PORT}/api"


### PR DESCRIPTION
Resolves #8 

To test this works:

1. Start the containers
2. Sign in as the administrator 
3. Click on the user menu (top-right corner) and select "Configuration" 
4. Click the "Add" button 
5. Under "Select the property to add", select "feature.use_open_id_connect" 
6. Under "Value", select "Yes". 
7. Click "Add property" to save. 

If there is a new administrator screen available for "OpenID Connect", then the plugin has loaded successfully.